### PR TITLE
Update DeepSMOTE_MNIST.py

### DIFF
--- a/DeepSMOTE_MNIST.py
+++ b/DeepSMOTE_MNIST.py
@@ -291,9 +291,9 @@ for i in range(len(ids)):
                 
                 xcplus = np.append(xcminus,0)
                 #print('xcplus ',xcplus)
-                xcnew = (xclass[[xcplus],:])
+                xcnew = np.copy(xclass)
                 #xcnew = np.squeeze(xcnew)
-                xcnew = xcnew.reshape(xcnew.shape[1],xcnew.shape[2],xcnew.shape[3],xcnew.shape[4])
+                #xcnew = xcnew.reshape(xcnew.shape[1],xcnew.shape[2],xcnew.shape[3],xcnew.shape[4])
                 #print('xcnew ',xcnew.shape)
             
                 xcnew = torch.Tensor(xcnew)


### PR DESCRIPTION

Hello ,**dd1github** .
My name is Andy,a master student who is recently study at National Taiwan University.

Recently I am interested at dealing with imbalanced data and finding such great work
 '**DeepSMOTE: Fusing Deep Learning and SMOTE**', while reading the codes from your repo,
I noticed that there might be a little mistake in the implementation.

At line 312: mse2 compare the distance between ximg and xcnew, in my opinion, xcnew just need to copy xclass without permutation, where ximg is generated by the permuted feature vectors of the original images,which means xcnew and xclass aren't from the same image initially.
                
For instance,while calculating mse2,order of xcnew = (1,2,3) , order of ximg = (2,3,1).
As I delved into the paper,this permutation aims at generating the artificial image during inference, in other words, we hope the decoder generate artificial images by feature vectors of neighbors in the original images' own class,while such artificial images would look like the original images

"as if an image was oversampled by SMOTE (i.e., as if an image were generated based on the difference between an image and the image’s neighbor). "quoted from the reference paper "DeepSMOTE: Fusing Deep Learning and SMOTE for Imbalanced Data" 

As I mentioned earlier,I am really interested in the paper and its implementation,
please feel free to discuss with me,I will really appreciate your kindness.!

Look forward to your response at your earliest convenience!
Sincerely